### PR TITLE
updated chartmogul dependency to 4.6.1, fixed readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,6 @@ CHARTMOGUL_TOKEN=<YOUR-CHARTMOGUL-TOKEN>
 
 5. Run `source .venv/bin/activate` to activate the created virtual environment.
 
-6. Run `mcp dev main.py` to start the MCP server.
+6. Run `mcp dev main.py:cm_mcp` to start the development MCP server. This command will need Node.js and npm installation.
+
+7. Inspect and connect to the MCP server at http://127.0.0.1:6274

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from chartmogul_mcp import mcp_server
 
+cm_mcp = mcp_server.ChartMogulMcp()
 
 if __name__ == "__main__":
-    cm_mcp = mcp_server.ChartMogulMcp()
     cm_mcp.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "chartmogul-mcp-server"
-version = "0.1.0"
+version = "0.2.0"
 description = "ChartMogul's MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "chartmogul>=4.6.0",
+    "chartmogul>=4.6.1",
     "mcp[cli]>=1.7.1",
     "python-dotenv>=1.1.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -57,7 +57,7 @@ wheels = [
 
 [[package]]
 name = "chartmogul"
-version = "4.6.0"
+version = "4.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "future" },
@@ -67,11 +67,11 @@ dependencies = [
     { name = "uritemplate" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/b6/4b4c84b72d5a1298265bb3767e327914cafd552814fa4886872df57f3f6f/chartmogul-4.6.0.tar.gz", hash = "sha256:5ed8152db7485c0dee854644d23cb8d935cf269372ba9d4c0f790942ba1f37e9", size = 17330, upload_time = "2025-04-28T03:16:35.117Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/c4/d4f6872599dad9a7c74903ad79f169671519adb56d283bfa7c11bb84d51e/chartmogul-4.6.1.tar.gz", hash = "sha256:8ff6335e17d5d88c91b6b2dbe8a32d298bc868515ed4b458edde1e5dbedc1015", size = 17348, upload_time = "2025-05-19T08:55:17.775Z" }
 
 [[package]]
 name = "chartmogul-mcp-server"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "chartmogul" },
@@ -81,7 +81,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "chartmogul", specifier = ">=4.6.0" },
+    { name = "chartmogul", specifier = ">=4.6.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.7.1" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
 ]


### PR DESCRIPTION
Changes include:
- updated chartmogul dependency to 4.6.1
- fixed readme for mcp server development

Will publish new version to pypi.